### PR TITLE
Add options to take screenshot

### DIFF
--- a/lib/rspec/visual/helpers/screenshot_helper.rb
+++ b/lib/rspec/visual/helpers/screenshot_helper.rb
@@ -1,7 +1,10 @@
 require 'rspec/visual/configuration'
 module ScreenshotHelper
-  def take_screenshot(page, example)
+  def take_screenshot(page, example, options = {})
+  	if options.empty?
+      options = {full: true}
+    end
     file_path = File.join(Rspec::Visual::Configuration.screenshot_folder, "#{example.description}.png")
-    page.save_screenshot(file_path, full: true)
+    page.save_screenshot(file_path, options)
   end
 end


### PR DESCRIPTION
If no options is given maintain the original full: true

With this we can take scrennshots of elements:

take_screenshot(page, "footer", selector: 'footer')
